### PR TITLE
Remove "Clowder is not enabled" message

### DIFF
--- a/pkg/api/v1/config.go
+++ b/pkg/api/v1/config.go
@@ -41,7 +41,6 @@ func IsClowderEnabled() bool {
 
 func init() {
 	if !IsClowderEnabled() {
-		fmt.Println("Clowder is not enabled, skipping init...")
 		return
 	}
 	loadedConfig, err := loadConfig(os.Getenv("ACG_CONFIG"))


### PR DESCRIPTION
Hello, in our app, we use the same configuration for the backend app as well as for many CLI tools and this message is just always there. I see no big value in having anything on standard output, we use logging (and cloudwatch) anyways.

I'd appreciate a minor release with this so it goes away for good :-) Thanks a bunch, cheers!